### PR TITLE
chore: replace deprecated set-output with writing to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 # Test the action itself
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   android:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Dependencies
 
 * Update `action/upload-artifact` to v3 to prepare for GHA [dropping Node12 support](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
+* Replace [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) set-output with writing to `GITHUB_OUTPUT`.  
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## Unreleased
+## 1.4.0
+
+### Changes
+
+* Replace [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) set-output with writing to `GITHUB_OUTPUT`.
 
 ### Dependencies
 
 * Update `action/upload-artifact` to v3 to prepare for GHA [dropping Node12 support](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
-* Replace [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) set-output with writing to `GITHUB_OUTPUT`.  
 
 ## 1.3.0
 

--- a/action.yml
+++ b/action.yml
@@ -55,21 +55,3 @@ runs:
       with:
         name: ${{ steps.process.outputs.artifactName }}
         path: ${{ steps.process.outputs.artifactPath }}
-
-    - name: Find Comment
-      uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d # v2.0.0
-      if: github.event.pull_request.number
-      id: fc
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: ${{ steps.process.outputs.commentTitle }}
-
-    - name: Create or update comment
-      uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32 # v2.0.0
-      if: github.event.pull_request.number
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        edit-mode: replace
-        body: ${{ steps.process.outputs.commentBody }}

--- a/src/main/kotlin/Git.kt
+++ b/src/main/kotlin/Git.kt
@@ -7,7 +7,7 @@ class Git {
         val branch: String by lazy {
             if (!System.getenv("GITHUB_HEAD_REF").isNullOrEmpty()) {
                 System.getenv("GITHUB_HEAD_REF")
-            } else if (System.getenv("GITHUB_REF").startsWith("refs/heads/")) {
+            } else if (System.getenv("GITHUB_REF")?.startsWith("refs/heads/") == true) {
                 System.getenv("GITHUB_REF").removePrefix("refs/heads/")
             } else {
                 executeCommand("git branch --show-current")

--- a/src/main/kotlin/Git.kt
+++ b/src/main/kotlin/Git.kt
@@ -4,19 +4,31 @@ import java.io.InputStreamReader
 
 class Git {
     companion object {
+        private val env = System.getenv()
         val branch: String by lazy {
-            if (!System.getenv("GITHUB_HEAD_REF").isNullOrEmpty()) {
-                System.getenv("GITHUB_HEAD_REF")
-            } else if (System.getenv("GITHUB_REF")?.startsWith("refs/heads/") == true) {
-                System.getenv("GITHUB_REF").removePrefix("refs/heads/")
+            if (!env["GITHUB_HEAD_REF"].isNullOrEmpty()) {
+                env["GITHUB_HEAD_REF"]!!
+            } else if (env["GITHUB_REF"]?.startsWith("refs/heads/") == true) {
+                env["GITHUB_REF"]!!.removePrefix("refs/heads/")
             } else {
                 executeCommand("git branch --show-current")
             }
         }
 
         val baseBranch by lazy {
-            val baseRef = System.getenv("GITHUB_BASE_REF")
+            val baseRef = env["GITHUB_BASE_REF"]
             if (baseRef.isNullOrEmpty()) defaultBranch else baseRef
+        }
+
+        val repository by lazy {
+            var repo = env["GITHUB_REPOSITORY"]
+            if (repo.isNullOrEmpty()) {
+                repo = executeCommand("git remote get-url origin")
+                repo = repo!!.removePrefix("git@").removeSuffix(".git")
+                repo!!.replace(':', '/')
+            } else {
+                "github.com/$repo"
+            }
         }
 
         private val workingDirectory =

--- a/src/main/kotlin/GitHub.kt
+++ b/src/main/kotlin/GitHub.kt
@@ -1,8 +1,27 @@
+import org.kohsuke.github.GHWorkflow
+import org.kohsuke.github.GHWorkflowRun
+import org.kohsuke.github.GitHubBuilder
 import java.io.FileOutputStream
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import kotlin.io.path.createDirectories
 
 class GitHub {
     companion object {
-        private val outputFile = System.getenv("GITHUB_OUTPUT")
+        private val env = System.getenv()
+        private val outputFile = env["GITHUB_OUTPUT"]
+        private val token = env["GITHUB_TOKEN"]
+        private val github =
+            if (token.isNullOrEmpty()) null else GitHubBuilder().withOAuthToken(token).build()
+        private val repo = github?.getRepository(env["GITHUB_REPOSITORY"]!!)
+        private val workflow: GHWorkflow? by lazy {
+            repo?.listWorkflows()?.single {
+                // GITHUB_WORKFLOW: The name of the workflow. For example, My test workflow. If the workflow file doesn't
+                // specify a name, the value of this variable is the full path of the workflow file in the repository.
+                listOf(it.name, it.path).contains(env["GITHUB_WORKFLOW"]!!)
+            }
+        }
 
         fun writeOutput(name: String, value: Any) {
             if (!outputFile.isNullOrEmpty()) {
@@ -14,6 +33,57 @@ class GitHub {
                 }
             }
             println("Output $name=$value")
+        }
+
+        fun downloadPreviousArtifact(branch: String, targetDir: Path, artifactName: String) {
+            targetDir.createDirectories()
+
+            if (workflow == null) {
+                println("Skipping previous artifact '$artifactName' download for branch '$branch' - not running in CI")
+                return
+            }
+            println("Trying to download previous artifact '$artifactName' for branch '$branch'")
+
+            val run = workflow!!.listRuns()
+                .firstOrNull { it.headBranch == branch && it.conclusion == GHWorkflowRun.Conclusion.SUCCESS }
+            if (run == null) {
+                println("Couldn't find any successful run workflow ${workflow!!.name}")
+                return
+            }
+
+            val artifact = run.listArtifacts().firstOrNull { it.name == artifactName }
+            if (artifact == null) {
+                println("Couldn't find any artifact matching $artifactName")
+                return
+            }
+
+            println("Downloading artifact ${artifact.archiveDownloadUrl} and extracting to $targetDir")
+            artifact.download {
+                val zipStream = ZipInputStream(it)
+                var entry: ZipEntry?
+                // while there are entries I process them
+                while (true) {
+                    entry = zipStream.nextEntry
+                    if (entry == null) {
+                        break
+                    }
+                    if (entry.isDirectory) {
+                        Path.of(entry.name).createDirectories()
+                    } else {
+                        println("Extracting ${entry.name}")
+                        val outFile = FileOutputStream(targetDir.resolve(entry.name).toFile())
+                        while (zipStream.available() > 0) {
+                            val c = zipStream.read()
+                            if (c > 0) {
+                                outFile.write(c)
+                            } else {
+                                break
+                            }
+                        }
+                        outFile.close()
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/GitHub.kt
+++ b/src/main/kotlin/GitHub.kt
@@ -120,7 +120,11 @@ class GitHub {
                 file.writeText(commentBuilder.body)
             } else {
                 val comments = pullRequest!!.comments
-                val author = github!!.myself.login
+                // Trying to fetch `github!!.myself` throws (in CI only): Exception in thread "main" org.kohsuke.github.HttpException:
+                //   {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/users#get-the-authenticated-user"}
+                // Let's make this conditional on some env variable that's unlikely to be set.
+                // Do not use "CI" because that's commonly set during local development and testing.
+                val author = if(env.containsKey("GITHUB_ACTION")) "github-actions[bot]" else github!!.myself.login
                 val comment = comments.firstOrNull {
                     it.user.login.equals(author) &&
                             it.body.startsWith(commentBuilder.title, ignoreCase = true)

--- a/src/main/kotlin/GitHub.kt
+++ b/src/main/kotlin/GitHub.kt
@@ -131,7 +131,7 @@ class GitHub {
                 }
                 if (comment != null) {
                     println("Updating PR comment ${comment.htmlUrl} body")
-                    comment.update(comment.body)
+                    comment.update(commentBuilder.body)
                 } else {
                     println("Adding new PR comment to ${pullRequest!!.htmlUrl}")
                     pullRequest!!.comment(commentBuilder.body)

--- a/src/main/kotlin/GitHub.kt
+++ b/src/main/kotlin/GitHub.kt
@@ -1,0 +1,19 @@
+import java.io.FileOutputStream
+
+class GitHub {
+    companion object {
+        private val outputFile = System.getenv("GITHUB_OUTPUT")
+
+        fun writeOutput(name: String, value: Any) {
+            if (!outputFile.isNullOrEmpty()) {
+                FileOutputStream(outputFile, true).bufferedWriter().use { writer ->
+                    writer.write(name)
+                    writer.write('='.code)
+                    writer.write(value.toString())
+                    writer.write('\n'.code)
+                }
+            }
+            println("Output $name=$value")
+        }
+    }
+}

--- a/src/main/kotlin/PrCommentBuilder.kt
+++ b/src/main/kotlin/PrCommentBuilder.kt
@@ -9,8 +9,8 @@ class PrCommentBuilder {
             body = body.replace("%", "%25")
             body = body.replace("\n", "%0A")
             body = body.replace("\r", "%0D")
-            println("::set-output name=commentBody::$body")
-            println("::set-output name=commentTitle::$title")
+            GitHub.writeOutput("commentTitle", title)
+            GitHub.writeOutput("commentBody", body)
         } else {
             File("out/comment.html").writeText(body)
         }

--- a/src/main/kotlin/PrCommentBuilder.kt
+++ b/src/main/kotlin/PrCommentBuilder.kt
@@ -1,22 +1,8 @@
-import java.io.File
-
 class PrCommentBuilder {
     private var buffer = StringBuilder()
 
-    fun print(isCI: Boolean) {
-        var body = buffer.toString()
-        if (isCI) {
-            body = body.replace("%", "%25")
-            body = body.replace("\n", "%0A")
-            body = body.replace("\r", "%0D")
-            GitHub.writeOutput("commentTitle", title)
-            GitHub.writeOutput("commentBody", body)
-        } else {
-            File("out/comment.html").writeText(body)
-        }
-    }
-
-    private val title get() = "## ${System.getenv("RESULT_NAME") ?: ""} Performance metrics :rocket:"
+    val title get() = "## ${System.getenv("RESULT_NAME") ?: ""} Performance metrics :rocket:"
+    val body get() = buffer.toString()
 
     fun addCurrentResult(result: ResultFile) = addResult(title, result)
 

--- a/src/main/kotlin/ResultProcessor.kt
+++ b/src/main/kotlin/ResultProcessor.kt
@@ -33,11 +33,8 @@ class ResultProcessor {
 
         downloadResults()
 
-        if (isCI) {
-            println("::echo::on")
-            println("::set-output name=artifactName::$artifactName")
-            println("::set-output name=artifactPath::${previousResultsDir.absolutePathString()}")
-        }
+        GitHub.writeOutput("artifactName", artifactName)
+        GitHub.writeOutput("artifactPath", previousResultsDir.absolutePathString())
 
         val prComment = PrCommentBuilder()
         prComment.addCurrentResult(latestResults)
@@ -52,10 +49,6 @@ class ResultProcessor {
             ResultsSet(previousResultsDir)
         )
         prComment.print(isCI)
-
-        if (isCI) {
-            println("::echo::off")
-        }
 
         // Copy the latest test run results to the archived result dir.
         ResultsSet(previousResultsDir).add(latestResults.path, info = Git.hash)

--- a/src/main/kotlin/ResultProcessor.kt
+++ b/src/main/kotlin/ResultProcessor.kt
@@ -7,7 +7,6 @@ fun main() = ResultProcessor().main()
 
 class ResultProcessor {
     private val env = System.getenv()
-    private val isCI = env.containsKey("CI")
     private val artifactName =
         "app-sdk-metrics-results" + (if (env["RESULT_NAME"].isNullOrEmpty()) "" else "-${env["RESULT_NAME"]}")
 
@@ -42,7 +41,8 @@ class ResultProcessor {
             "Previous results on branch: ${Git.branch}",
             ResultsSet(previousResultsDir)
         )
-        prComment.print(isCI)
+
+        GitHub.addOrUpdateComment(prComment)
 
         // Copy the latest test run results to the archived result dir.
         ResultsSet(previousResultsDir).add(latestResults.path, info = Git.hash)


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

this broke escaping of multi-line outputs so I've also had to move adding/updating PR comments to Kotlin, instead of a 3rd-party action that was used previously.