### PR TITLE
Update appium version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 * Update Appium version used in Sauce Labs from EOL `2.0.0` to `appium2-20240701` ([#13](https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/13))
 
-### Dependencies
-
-* Update `action/checkout`, `action/setup-java` and `action/upload-artifact` to the latest versions due to NodeJS 16 deprecation in actions.
-
 ## 1.5.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.6.0
+
+### Fixes
+
+* Update Appium version used in Sauce Labs from EOL `2.0.0` to `appium2-20240701` ([#13](https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/13))
+
+### Dependencies
+
+* Update `action/checkout`, `action/setup-java` and `action/upload-artifact` to the latest versions due to NodeJS 16 deprecation in actions.
+
 ## 1.5.0
 
 ### Features

--- a/src/test/kotlin/TestOptions.kt
+++ b/src/test/kotlin/TestOptions.kt
@@ -125,7 +125,7 @@ data class TestOptions(
                 val env = System.getenv()
                 val sauceOptions = MutableCapabilities()
                 // Appium v2 required for Android logcat access.
-                sauceOptions.setCapability("appiumVersion", "2.0.0")
+                sauceOptions.setCapability("appiumVersion", "appium2-20240701")
                 sauceOptions.setCapability("name", "Performance tests")
                 sauceOptions.setCapability(
                     "build",


### PR DESCRIPTION
Fixes #12 

updates to `appium2-20240701` which should EOL on Jun 30th 2025