### PR TITLE
Android: Adds measureActivity test option

### DIFF
--- a/src/test/kotlin/StartupTimeTest.kt
+++ b/src/test/kotlin/StartupTimeTest.kt
@@ -6,7 +6,6 @@ import io.appium.java_client.android.AndroidDriver
 import io.appium.java_client.ios.IOSDriver
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
-import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import kotlin.math.abs

--- a/src/test/kotlin/StartupTimeTest.kt
+++ b/src/test/kotlin/StartupTimeTest.kt
@@ -8,6 +8,9 @@ import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.FluentWait
+import java.time.Duration
 import kotlin.math.abs
 import kotlin.math.ceil
 
@@ -194,14 +197,13 @@ class StartupTimeTest : TestBase() {
     private fun AndroidDriver.waitForActivity(
         desiredActivity: String,
         sleepMs: Long = sleepTimeMs,
-        maxWaitLoops: Int = 50
+        timeOutMs: Long = 10_000,
     ) {
         printf("Waiting for activity: %s", desiredActivity)
-        var counter = 0
-        while (currentActivity()?.contains(desiredActivity) == false && counter <= maxWaitLoops) {
-            Thread.sleep(sleepMs)
-            counter++
-        }
+        val wait = FluentWait<WebDriver>(this)
+            .withTimeout(Duration.ofMillis(timeOutMs))
+            .pollingEvery(Duration.ofMillis(sleepMs))
+        wait.until { currentActivity()?.contains(desiredActivity) }
         printf("Current activity: %s", currentActivity())
     }
 

--- a/src/test/kotlin/TestOptions.kt
+++ b/src/test/kotlin/TestOptions.kt
@@ -15,7 +15,12 @@ import java.util.logging.Logger
 import kotlin.io.path.createDirectories
 import kotlin.io.path.notExists
 
-data class AppInfo(val name: String, val activity: String? = null, val path: String) {
+data class AppInfo(
+    val name: String,
+    val activity: String? = null,
+    val path: String,
+    val measureActivity: String? = null
+) {
     private val pathIsUrl = path.contains(':')
 
     val file: Path by lazy {


### PR DESCRIPTION
This PR adds a separate optional test option `measureActivity` that can be used to specify [the activity to be tracked for measuring start up time](https://github.com/getsentry/action-app-sdk-overhead-metrics/blob/v1.8.0/src/test/kotlin/StartupTimeTest.kt#L223) separately [from the startup `activity`](https://github.com/getsentry/action-app-sdk-overhead-metrics/blob/v1.8.0/src/test/kotlin/StartupTimeTest.kt#L209).
 
This is needed on https://github.com/getsentry/sentry-react-native to correctly measure loading time since the main activity of the application is displayed before RN starts executing and thus before the JS SDK inits.

See https://github.com/getsentry/sentry-react-native/pull/4292 for how this intents to be used.