### PR TITLE
Appium stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Set appium version to stable (#24)
+
 ## 1.8.0
 
 ### Features

--- a/src/test/kotlin/TestOptions.kt
+++ b/src/test/kotlin/TestOptions.kt
@@ -125,7 +125,7 @@ data class TestOptions(
                 val env = System.getenv()
                 val sauceOptions = MutableCapabilities()
                 // Appium v2 required for Android logcat access.
-                sauceOptions.setCapability("appiumVersion", "appium2-stable")
+                sauceOptions.setCapability("appiumVersion", "stable")
                 sauceOptions.setCapability("name", "Performance tests")
                 sauceOptions.setCapability(
                     "build",

--- a/src/test/kotlin/TestOptions.kt
+++ b/src/test/kotlin/TestOptions.kt
@@ -125,7 +125,7 @@ data class TestOptions(
                 val env = System.getenv()
                 val sauceOptions = MutableCapabilities()
                 // Appium v2 required for Android logcat access.
-                sauceOptions.setCapability("appiumVersion", "appium2-20240701")
+                sauceOptions.setCapability("appiumVersion", "appium2-stable")
                 sauceOptions.setCapability("name", "Performance tests")
                 sauceOptions.setCapability(
                     "build",


### PR DESCRIPTION
Previous version of Appium reached EOL (and it is no longer available).

Set it to stable so we don't need to worry unless there is a breakign change (like appium 3)

See https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-versions/#end-of-life